### PR TITLE
Set the same color for links in the gtk-2 theme as in the gtk-3 one

### DIFF
--- a/Breeze-gtk/gtk-2.0/gtkrc
+++ b/Breeze-gtk/gtk-2.0/gtkrc
@@ -77,6 +77,9 @@ style "default"
 
 	GtkEntry::state-hint            			= 1
 
+	GtkWidget::link-color		= "#1998DA"
+	GtkWidget::visited-link-color	= "#1478AC"
+
 	# Colors
 
 	bg[NORMAL]		= @bg_color


### PR DESCRIPTION
The gtk-2 theme was not setting the color for hyperlinks. This pr uses the same colors as gtk-3.0/gtk.css
