### PR TITLE
Gtk2: Fix states of arrows

### DIFF
--- a/Breeze-dark-gtk/gtk-2.0/gtkrc
+++ b/Breeze-dark-gtk/gtk-2.0/gtkrc
@@ -285,6 +285,7 @@ style "default"
 	image
 	{
 	  function			= ARROW
+	  state				= NORMAL
 	  overlay_file			= "Arrows/arrow-up.png"
 	  overlay_border		= { 0, 0, 0, 0 }
 	  overlay_stretch		= FALSE

--- a/Breeze-gtk/gtk-2.0/gtkrc
+++ b/Breeze-gtk/gtk-2.0/gtkrc
@@ -367,6 +367,7 @@ style "default"
 	image
 	{
 	  function			= ARROW
+	  state				= NORMAL
 	  overlay_file			= "Arrows/arrow-left.png"
 	  overlay_border		= { 0, 0, 0, 0 }
 	  overlay_stretch		= FALSE
@@ -403,6 +404,7 @@ style "default"
 	image
 	{
 	    function			= ARROW
+	    state			= NORMAL
 	    overlay_file		= "Arrows/arrow-right.png"
 	    overlay_border		= { 0, 0, 0, 0 }
 	    overlay_stretch		= FALSE

--- a/Breeze-gtk/gtk-2.0/gtkrc
+++ b/Breeze-gtk/gtk-2.0/gtkrc
@@ -292,6 +292,7 @@ style "default"
 	image
 	{
 	  function			= ARROW
+	  state				= NORMAL
 	  overlay_file			= "Arrows/arrow-up.png"
 	  overlay_border		= { 0, 0, 0, 0 }
 	  overlay_stretch		= FALSE


### PR DESCRIPTION
Not specifying state assumes that the style should be used for
all states. This made the arrows always enabled.
